### PR TITLE
Allow overriding of the Content-Type header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.json
 test/config.json
 .idea
 docs
+.nyc_output/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-logging",
-  "version": "0.11.1",
+  "version": "0.11.2000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-logging",
-  "version": "0.11.1",
+  "version": "0.11.2000",
   "description": "Splunk HTTP Event Collector logging interface",
   "homepage": "http://dev.splunk.com",
   "main": "index.js",

--- a/splunklogger.js
+++ b/splunklogger.js
@@ -50,8 +50,8 @@ function _defaultEventFormatter(message, severity) {
 }
 
 /**
- * Constructs a SplunkLogger, to send events to Splunk Enterprise or Splunk Cloud 
- * via HTTP Event Collector. See <code>defaultConfig</code> for default 
+ * Constructs a SplunkLogger, to send events to Splunk Enterprise or Splunk Cloud
+ * via HTTP Event Collector. See <code>defaultConfig</code> for default
  * configuration settings.
  *
  * @example
@@ -83,7 +83,7 @@ function _defaultEventFormatter(message, severity) {
  * @param {string} [config.protocol=https] - Protocol used to communicate with the Splunk Enterprise or Splunk Cloud server, <code>http</code> or <code>https</code>.
  * @param {number} [config.port=8088] - HTTP Event Collector port on the Splunk Enterprise or Splunk Cloud server.
  * @param {string} [config.url] - URL string to pass to {@link https://nodejs.org/api/url.html#url_url_parsing|url.parse}. This will try to set
- * <code>host</code>, <code>path</code>, <code>protocol</code>, <code>port</code>, <code>url</code>. Any of these values will be overwritten if 
+ * <code>host</code>, <code>path</code>, <code>protocol</code>, <code>port</code>, <code>url</code>. Any of these values will be overwritten if
  * the corresponding property is set on <code>config</code>.
  * @param {string} [config.level=info] - Logging level to use, will show up as the <code>severity</code> field of an event, see
  *  [SplunkLogger.levels]{@link SplunkLogger#levels} for common levels.
@@ -135,7 +135,8 @@ SplunkLogger.prototype.levels = {
 };
 
 var defaultConfig = {
-    name: "splunk-javascript-logging/0.11.1",
+    contentType: "application/x-www-form-urlencoded",
+    name: "splunk-javascript-logging/0.11.2000",
     host: "localhost",
     path: "/services/collector/event/1.0",
     protocol: "https",
@@ -180,7 +181,7 @@ SplunkLogger.prototype._enableTimer = function(interval) {
     if (this._timerID) {
         this._disableTimer();
     }
-    
+
     // If batch interval is changed, update the config property
     if (this.config) {
         this.config.batchInterval = interval;
@@ -275,7 +276,7 @@ SplunkLogger.prototype._initializeConfig = function(config) {
         var startTimer = !this._timerID && ret.batchInterval > 0;
         // Has the interval timer already started, and the interval changed to a different duration?
         var changeTimer = this._timerID && this._timerDuration !== ret.batchInterval && ret.batchInterval > 0;
-        
+
         // Enable the timer
         if (startTimer || changeTimer) {
             this._enableTimer(ret.batchInterval);
@@ -284,6 +285,9 @@ SplunkLogger.prototype._initializeConfig = function(config) {
         else if (this._timerID && (ret.batchInterval <= 0 || this._timerDuration < 0)) {
             this._disableTimer();
         }
+
+        // Allow Content-Type header override from config
+        ret.contentType = utils.orByFalseyProp("contentType", config, ret, defaultConfig);
     }
     return ret;
 };
@@ -397,7 +401,7 @@ SplunkLogger.prototype._makeBody = function(context) {
     var body = this._initializeMetadata(context);
     var time = utils.formatTime(body.time || Date.now());
     body.time = time.toString();
-    
+
     body.event = this.eventFormatter(context.message, context.severity || defaultConfig.level);
     return body;
 };
@@ -436,7 +440,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
     requestOptions.headers["Authorization"] = "Splunk " + this.config.token;
     // Manually set the content-type header, the default is application/json
     // since json is set to true.
-    requestOptions.headers["Content-Type"] = "application/x-www-form-urlencoded";
+    requestOptions.headers["Content-Type"] = this.config.contentType;
     requestOptions.url = this.config.protocol + "://" + this.config.host + ":" + this.config.port + this.config.path;
 
     // Initialize the context again, right before using it
@@ -496,7 +500,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
         }
     );
 };
- 
+
 /**
  * Sends or queues data to be sent based on batching settings.
  * Default behavior is to send immediately.
@@ -505,8 +509,8 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  * var SplunkLogger = require("splunk-logging").Logger;
  * var config = {
  *     token: "your-token-here"
- * }; 
- * 
+ * };
+ *
  * var logger = new SplunkLogger(config);
  *
  * // Payload to send to HTTP Event Collector.
@@ -522,7 +526,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  *         index: "main",
  *         host: "farm.local",
  *     }
- * }; 
+ * };
  *
  * // The callback is only used if maxBatchCount=1, or
  * // batching thresholds have been exceeded.
@@ -549,7 +553,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  */
 SplunkLogger.prototype.send = function(context, callback) {
     context = this._initializeContext(context);
-    
+
     // Store the context, and its estimated length
     var currentEvent = JSON.stringify(this._makeBody(context));
     this.serializedContextQueue.push(currentEvent);
@@ -583,7 +587,7 @@ SplunkLogger.prototype.flush = function(callback) {
     var context = {
         message: data
     };
-    
+
     this._sendEvents(context, callback);
 };
 

--- a/test/test_config.js
+++ b/test/test_config.js
@@ -134,7 +134,7 @@ describe("SplunkLogger", function() {
             var logger = new SplunkLogger(config);
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -153,7 +153,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -184,7 +184,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -291,7 +291,7 @@ describe("SplunkLogger", function() {
             assert.ok(logger._timerID);
 
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -310,7 +310,7 @@ describe("SplunkLogger", function() {
             assert.ok(!logger._timerID);
 
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -391,7 +391,7 @@ describe("SplunkLogger", function() {
             assert.ok(!logger._timerID);
 
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("http", logger.config.protocol);
@@ -408,7 +408,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual(config.path, logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -425,7 +425,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -442,7 +442,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -460,7 +460,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("splunk.local", logger.config.host);
             assert.strictEqual("/services/collector/different/1.0", logger.config.path);
             assert.strictEqual("http", logger.config.protocol);
@@ -477,7 +477,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("http", logger.config.protocol);
@@ -494,7 +494,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("splunk.local", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("http", logger.config.protocol);
@@ -511,7 +511,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("splunk.local", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("http", logger.config.protocol);
@@ -528,7 +528,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("splunk.local", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -545,7 +545,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(logger);
             assert.strictEqual(config.token, logger.config.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", logger.config.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", logger.config.name);
             assert.strictEqual("localhost", logger.config.host);
             assert.strictEqual("/services/collector/event/1.0", logger.config.path);
             assert.strictEqual("https", logger.config.protocol);
@@ -679,7 +679,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("localhost", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("https", loggerConfig.protocol);
@@ -698,7 +698,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("localhost", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("https", loggerConfig.protocol);
@@ -717,7 +717,7 @@ describe("SplunkLogger", function() {
             var loggerConfig = SplunkLogger.prototype._initializeConfig(config);
 
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("localhost", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("http", loggerConfig.protocol);
@@ -736,7 +736,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("localhost", loggerConfig.host);
             assert.strictEqual(config.path, loggerConfig.path);
             assert.strictEqual("https", loggerConfig.protocol);
@@ -755,7 +755,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("localhost", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("https", loggerConfig.protocol);
@@ -774,7 +774,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("splunk.local", loggerConfig.host);
             assert.strictEqual("/services/collector/different/1.0", loggerConfig.path);
             assert.strictEqual("http", loggerConfig.protocol);
@@ -793,7 +793,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("localhost", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("http", loggerConfig.protocol);
@@ -812,7 +812,7 @@ describe("SplunkLogger", function() {
 
             assert.ok(loggerConfig);
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("splunk.local", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("https", loggerConfig.protocol);
@@ -833,7 +833,7 @@ describe("SplunkLogger", function() {
             assert.ok(loggerConfig);
             assert.ok(!loggerConfig.hasOwnProperty("something"));
             assert.strictEqual(config.token, loggerConfig.token);
-            assert.strictEqual("splunk-javascript-logging/0.11.1", loggerConfig.name);
+            assert.strictEqual("splunk-javascript-logging/0.11.2000", loggerConfig.name);
             assert.strictEqual("splunk.local", loggerConfig.host);
             assert.strictEqual("/services/collector/event/1.0", loggerConfig.path);
             assert.strictEqual("https", loggerConfig.protocol);
@@ -842,6 +842,25 @@ describe("SplunkLogger", function() {
             assert.strictEqual(0, loggerConfig.maxRetries);
             assert.strictEqual(0, loggerConfig.batchInterval);
             assert.strictEqual(0, loggerConfig.maxBatchSize);
+        });
+        it("should use the default contentType if not overriden", function() {
+            var config = {
+                token: "a-token-goes-here-usually",
+                url: "splunk.local"
+            };
+            var loggerConfig = SplunkLogger.prototype._initializeConfig(config);
+
+            assert.strictEqual("application/x-www-form-urlencoded", loggerConfig.contentType);
+        });
+        it("should set the contentType if overriden", function() {
+            var config = {
+                token: "a-token-goes-here-usually",
+                url: "splunk.local",
+                contentType: "application/json"
+            };
+            var loggerConfig = SplunkLogger.prototype._initializeConfig(config);
+
+            assert.strictEqual("application/json", loggerConfig.contentType);
         });
     });
     describe("_initializeRequestOptions", function() {
@@ -959,7 +978,7 @@ describe("SplunkLogger", function() {
 
             var expected = {
                 token: config.token,
-                name: "splunk-javascript-logging/0.11.1",
+                name: "splunk-javascript-logging/0.11.2000",
                 host: "localhost",
                 path: "/services/collector/event/1.0",
                 protocol: "https",
@@ -993,7 +1012,7 @@ describe("SplunkLogger", function() {
 
             var expected = {
                 token: config.token,
-                name: "splunk-javascript-logging/0.11.1",
+                name: "splunk-javascript-logging/0.11.2000",
                 host: "localhost",
                 path: "/services/collector/event/1.0",
                 protocol: "https",


### PR DESCRIPTION
Looking at the migration from Splunk Cloud to Log Observer from a different angle...

Thus far, this effort has been painful. In fact, in each Signpost repo that we have tried migrating, we have encountered different issues - e.g. different log formats, different loggers, trouble installing npm packages...

We don't have a requirement to log both Splunk Cloud and Log Observer as part of this migration. A path forward exists where we can move dev environments to Log Observer, keeping production pointing at Splunk Cloud, validate that dev works as desired + migrate the necessary dashboards and alerts, then finally migrate production.

I believe that path would be much easier for us, and we could continue to use the same logging code that we use today. In my testing, I can log to both Splunk Cloud and Log Observer using this package with one small change - Log Observer requires the Content-Type header to be `application/json`. Splunk Cloud doesn't seem to care and will accept logs with either Content-Type. This package currently hardcodes it as `application/x-www-form-urlencoded`, and this PR will allow that to be overriden. Splunk Cloud doesn't seem to care about the change to application/json, but this should allow us to keep it the same to minimize the risk of something going wrong.

Let me know your thoughts

Note this is a public repo